### PR TITLE
feat: transparent background setting for translucent themes

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -1,10 +1,20 @@
-import { Plugin, ItemView, WorkspaceLeaf, App, TFile, setIcon, SuggestModal, Modal, Menu } from "obsidian";
+import { Plugin, PluginSettingTab, Setting, ItemView, WorkspaceLeaf, App, TFile, setIcon, SuggestModal, Modal, Menu } from "obsidian";
 import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import type { ChildProcess } from "child_process";
 
 const VIEW_TYPE = "vin-terminal-view";
 let ptyHelperPath = "";
+
+interface VinTerminalSettings {
+  transparentBackground: boolean;
+}
+
+const DEFAULT_SETTINGS: VinTerminalSettings = {
+  transparentBackground: false,
+};
+
+let vinTerminalSettings: VinTerminalSettings = { ...DEFAULT_SETTINGS };
 
 const PTY_HELPER_PY = `\
 """PTY helper for vin-terminal. Wraps zsh in a real PTY with resize support."""
@@ -97,7 +107,9 @@ function getObsidianTheme(): Record<string, string> {
   const get = (v: string) => s.getPropertyValue(v).trim();
   const isDark = document.body.classList.contains("theme-dark");
 
-  const bg = get("--background-primary") || (isDark ? "#1e1e1e" : "#ffffff");
+  const bg = vinTerminalSettings.transparentBackground
+    ? "transparent"
+    : (get("--background-primary") || (isDark ? "#1e1e1e" : "#ffffff"));
   const fg = get("--text-normal") || (isDark ? "#dcddde" : "#1a1a1a");
   const accent = get("--interactive-accent") || (isDark ? "#7f6df2" : "#705dcf");
   const muted = get("--text-muted") || (isDark ? "#999" : "#666");
@@ -145,7 +157,9 @@ function getObsidianTheme(): Record<string, string> {
     background: bg,
     foreground: fg,
     cursor: muted,
-    cursorAccent: bg,
+    cursorAccent: vinTerminalSettings.transparentBackground
+      ? (isDark ? "#1e1e1e" : "#ffffff")
+      : bg,
     selectionBackground: isDark ? "rgba(255, 255, 255, 0.15)" : "rgba(0, 0, 0, 0.15)",
     selectionForeground: isDark ? "#f0f0f0" : "#1a1a1a",
     ...ansi,
@@ -742,6 +756,7 @@ class TerminalSession {
       fontWeight: "400",
       fontWeightBold: "600",
       theme: getObsidianTheme(),
+      allowTransparency: vinTerminalSettings.transparentBackground,
       allowProposedApi: true,
     });
 
@@ -1181,6 +1196,7 @@ class FullscreenManager {
 
     // Append to body
     document.body.appendChild(this.overlay);
+    document.body.classList.add("vin-fullscreen-active");
 
     // Animate in
     requestAnimationFrame(() => this.overlay?.classList.add("is-visible"));
@@ -1205,7 +1221,10 @@ class FullscreenManager {
 
     // Remove overlay after fade animation
     const overlay = this.overlay;
-    setTimeout(() => overlay.remove(), 150);
+    setTimeout(() => {
+      overlay.remove();
+      document.body.classList.remove("vin-fullscreen-active");
+    }, 150);
 
     // Clear refs immediately so re-entry works
     this.overlay = null;
@@ -1941,10 +1960,48 @@ class OutputCaptureModal extends SuggestModal<CaptureOption> {
   }
 }
 
+// --- Settings Tab ---
+
+class TerminalSettingTab extends PluginSettingTab {
+  plugin: TerminalPlugin;
+
+  constructor(app: App, plugin: TerminalPlugin) {
+    super(app, plugin);
+    this.plugin = plugin;
+  }
+
+  display(): void {
+    const { containerEl } = this;
+    containerEl.empty();
+    containerEl.createEl("h2", { text: "Terminal Settings" });
+
+    new Setting(containerEl)
+      .setName("Transparent background")
+      .setDesc(
+        "Use a transparent background so the terminal inherits its host panel's background. " +
+        "Best for translucent themes. Requires reload to take full effect."
+      )
+      .addToggle((toggle) =>
+        toggle
+          .setValue(vinTerminalSettings.transparentBackground)
+          .onChange(async (value) => {
+            vinTerminalSettings.transparentBackground = value;
+            await this.plugin.saveData(vinTerminalSettings);
+            this.plugin.applyTransparency();
+          })
+      );
+  }
+}
+
 // --- Plugin ---
 
 export default class TerminalPlugin extends Plugin {
   async onload() {
+    // Load settings
+    await this.loadSettings();
+    this.addSettingTab(new TerminalSettingTab(this.app, this));
+    this.applyTransparency();
+
     // Ensure pty-helper.py exists in the plugin directory.
     // BRAT and Obsidian's plugin installer only copy main.js, manifest.json,
     // and styles.css, so we write it ourselves on every load.
@@ -2096,7 +2153,31 @@ export default class TerminalPlugin extends Plugin {
     this.app.workspace.revealLeaf(leaf);
   }
 
+  async loadSettings() {
+    vinTerminalSettings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
+  }
+
+  applyTransparency() {
+    if (vinTerminalSettings.transparentBackground) {
+      document.body.classList.add("vin-terminal-transparent");
+    } else {
+      document.body.classList.remove("vin-terminal-transparent");
+    }
+    // Update existing terminal sessions
+    const leaves = this.app.workspace.getLeavesOfType(VIEW_TYPE);
+    for (const leaf of leaves) {
+      const view = leaf.view as TerminalView;
+      if (view.sessions) {
+        for (const s of view.sessions) {
+          s.terminal.options.theme = getObsidianTheme();
+          s.terminal.options.allowTransparency = vinTerminalSettings.transparentBackground;
+        }
+      }
+    }
+  }
+
   async onunload() {
+    document.body.classList.remove("vin-terminal-transparent");
     this.app.workspace.detachLeavesOfType(VIEW_TYPE);
   }
 }

--- a/styles.css
+++ b/styles.css
@@ -916,3 +916,104 @@ body:has(.vin-fullscreen-overlay.is-visible) > .menu {
   color: var(--text-faint);
   font-family: var(--font-interface);
 }
+
+/* ========================================
+   Transparent background mode
+   Activated via plugin settings toggle
+   ======================================== */
+
+body.vin-terminal-transparent .vin-terminal-container,
+body.vin-terminal-transparent .vin-terminal-tab-bar,
+body.vin-terminal-transparent .vin-terminal-session,
+body.vin-terminal-transparent .vin-fullscreen-pane {
+  background: transparent;
+}
+
+body.vin-terminal-transparent .xterm .xterm-viewport {
+  background-color: transparent !important;
+}
+
+body.vin-terminal-transparent .xterm .xterm-screen {
+  background: transparent !important;
+}
+
+body.vin-terminal-transparent .xterm .composition-view {
+  background: transparent;
+}
+
+/* Fullscreen: frosted glass overlay in transparent mode */
+body.vin-terminal-transparent .vin-fullscreen-overlay {
+  background: rgba(0, 0, 0, 0.4);
+}
+
+body.vin-terminal-transparent .vin-fs-tab-bar {
+  background: rgba(0, 0, 0, 0.3);
+  border-right-color: rgba(255, 255, 255, 0.08);
+}
+
+body.vin-terminal-transparent .vin-fullscreen-pane-label {
+  color: rgba(255, 255, 255, 0.3);
+  background: rgba(0, 0, 0, 0.2);
+  border-bottom-color: rgba(255, 255, 255, 0.06);
+}
+
+body.vin-terminal-transparent .vin-fs-tab {
+  border-color: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.5);
+}
+
+body.vin-terminal-transparent .vin-fs-tab:hover {
+  color: rgba(255, 255, 255, 0.8);
+  border-color: rgba(255, 255, 255, 0.15);
+  background: rgba(255, 255, 255, 0.05);
+}
+
+body.vin-terminal-transparent .vin-fs-tab-new {
+  border-color: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.3);
+}
+
+body.vin-terminal-transparent .vin-fs-tab-new:hover {
+  color: rgba(255, 255, 255, 0.7);
+  border-color: rgba(255, 255, 255, 0.15);
+}
+
+body.vin-terminal-transparent .vin-fs-controls {
+  border-top-color: rgba(255, 255, 255, 0.08);
+}
+
+body.vin-terminal-transparent .vin-fs-layout-group {
+  background: transparent !important;
+  border: none !important;
+}
+
+body.vin-terminal-transparent button.vin-fs-layout-btn {
+  color: rgba(255, 255, 255, 0.45);
+}
+
+body.vin-terminal-transparent button.vin-fs-layout-btn:hover {
+  color: rgba(255, 255, 255, 0.75);
+}
+
+body.vin-terminal-transparent .vin-fs-exit-btn {
+  border-color: rgba(255, 255, 255, 0.08) !important;
+  color: rgba(255, 255, 255, 0.45);
+}
+
+body.vin-terminal-transparent .vin-fs-exit-btn:hover {
+  color: rgba(255, 255, 255, 0.85);
+  border-color: rgba(255, 255, 255, 0.15) !important;
+}
+
+body.vin-terminal-transparent .vin-fs-tab-rename,
+body.vin-terminal-transparent .vin-fullscreen-overlay input[type="text"].vin-fs-tab-rename {
+  color: rgba(255, 255, 255, 0.85) !important;
+  border-bottom-color: rgba(255, 255, 255, 0.2) !important;
+  caret-color: rgba(255, 255, 255, 0.85) !important;
+}
+
+body.vin-terminal-transparent.vin-fullscreen-active > .app-container,
+body.vin-terminal-transparent.vin-fullscreen-active > .titlebar {
+  filter: blur(12px) brightness(0.5);
+  pointer-events: none;
+}


### PR DESCRIPTION
## Summary

- Adds a **Settings tab** (Settings > Terminal) with a "Transparent background" toggle
- When enabled, terminal containers become transparent so they inherit the host panel's background — matches Obsidian's translucent sidebar
- Fullscreen mode uses a frosted glass overlay with the workspace blurred behind it
- All fullscreen controls are restyled for the translucent aesthetic
- Default is **off** — original `var(--background-primary)` behavior is fully preserved
- Settings tab provides a foundation for future configuration options

## Context

With Obsidian's translucency enabled, the sidebar elements are set to `transparent !important` by Obsidian itself, and the visible background comes from the window compositor. Using `var(--background-primary)` for the terminal doesn't match the sidebar in this case. This setting gives users the option to make the terminal transparent so it blends seamlessly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)